### PR TITLE
Remove rfc numbers

### DIFF
--- a/0001-rfc-process/0001-rfc-process.md
+++ b/0001-rfc-process/0001-rfc-process.md
@@ -12,9 +12,8 @@ All ideas, thoughts, comments, suggestions, and eldritch ramblings, are valid an
 
 The following lists some basic formatting and housekeeping decisions concerning RFCs:
 
-- RFC numbers must be unique and increasing (i.e: take the next available number).
-- Each RFC must be in its own directory, with the directory name in the form `XXXX-$title`.
-- RFC filenames must be in the form `XXXX-$title.md`.
+- Each RFC must be in its own directory, with the directory name in the form `$title`.
+- RFC filenames must be in the form `$title`.
 - RFCs must be written in Markdown.
 
 The following lists some ideas towards RFC that are explicitly not presented:

--- a/rfc-process/rfc-process.md
+++ b/rfc-process/rfc-process.md
@@ -1,4 +1,4 @@
-# RFC 0001 - RFC Process
+# RFC Process
 
 This RFC describes the RFC process for Giant Swarm.
 


### PR DESCRIPTION
Manually created numbers aren't really helpful. My very first RFC already collided. Things will get merged in a different order. Some PRs will not even make it. So we will end up with lots of holes in the numbering anyway. Let's try this without numbers. It makes creating RFCs even easier and this was the main goal.