### PR TITLE
Add priorities to extra configs field in the multi layer app config RFC

### DIFF
--- a/multi-layer-app-config/README.md
+++ b/multi-layer-app-config/README.md
@@ -67,8 +67,7 @@ The merging algorithm is as follows:
 5. Configuration from `userConfig` entry (C)
 6. All entries from `extraConfigs` with priority of P: C < P
 
-In case of multiple items in `extraConfigs` having the same priority, the order on the list is binding, with the item lower on the list being merged later (overriding those higher on the list)
-in the list will take the priority.
+In case of multiple items in `extraConfigs` having the same priority, the order on the list is binding, with the item lower on the list being merged later (overriding those higher on the list).
 
 The idea is modeled after Flux's [HelmRelease configuration](https://fluxcd.io/docs/components/helm/api/#helm.toolkit.fluxcd.io/v2beta1.ValuesReference).
 

--- a/multi-layer-app-config/README.md
+++ b/multi-layer-app-config/README.md
@@ -52,7 +52,7 @@ Assuming the following priorities for the platform layers:
 
 - Catalog: A (e.g.: 0)
 - Cluster (`config`): B (e.g.: 50)
-- User (`userConfig`): (e.g.: 100)
+- User (`userConfig`): C (e.g.: 100)
 
 The distance (d) between each priority level should be the same.
 The `priority` field is validated on the CRD schema definition that it must be within range of: `[A, C + d]` and have

--- a/multi-layer-app-config/README.md
+++ b/multi-layer-app-config/README.md
@@ -67,7 +67,7 @@ The merging algorithm is as follows:
 5. Configuration from `userConfig` entry (C)
 6. All entries from `extraConfigs` with priority of P: C < P
 
-In case of multiple items in `extraConfigs` appear with the same priority then the item that appears first
+In case of multiple items in `extraConfigs` having the same priority, the order on the list is binding, with the item lower on the list being merged later (overriding those higher on the list)
 in the list will take the priority.
 
 The idea is modeled after Flux's [HelmRelease configuration](https://fluxcd.io/docs/components/helm/api/#helm.toolkit.fluxcd.io/v2beta1.ValuesReference).

--- a/multi-layer-app-config/README.md
+++ b/multi-layer-app-config/README.md
@@ -179,7 +179,7 @@ The merge order for config maps will be:
 1. ConfigMap: nginx-ingress-controller-high-priority (P = 10)
 1. ConfigMap: nginx-ingress-controller-pre-cluster (P = 25)
 1. ConfigMap: ingress-controller-values (P = 50)
-1. ConfigMap: nginx-ingress-controller-pre-user  (P = 75)
+1. ConfigMap: nginx-ingress-controller-pre-user (P = 75)
 1. ConfigMap: nginx-ingress-controller-app-user-values (P = 100)
 1. ConfigMap: nginx-ingress-controller-post-user (P = 125, position in the list: 1)
 1. ConfigMap: nginx-ingress-controller-final (P = 125, position in the list: 4)


### PR DESCRIPTION
The new `priorities` field makes it very flexible to apply new layers of configuration while still keeping backward compatibility. It supports our `gitops` use case and `late-binding` of configurations for `CAPI` clusters.