### PR TITLE
Add RFC for Container Registry Configuration

### DIFF
--- a/container-registry-configuration/README.md
+++ b/container-registry-configuration/README.md
@@ -143,7 +143,6 @@ We don't want to add another responsility to `cluster-apps-operator`.
 
 `6.a` is selected.
 
-
 ### 7. Where to put the credentials
 
 #### 7.a Customer's Git Repository
@@ -160,8 +159,7 @@ We can use catalog configurations (See <mc-name>/appcatalog folder in `installat
 
 #### Decision
 
-**NOT DECIDED YET**
-
+7.c is selected.
 
 ### 8. Configuration interface
 

--- a/container-registry-configuration/README.md
+++ b/container-registry-configuration/README.md
@@ -141,7 +141,7 @@ We don't want to add another responsility to `cluster-apps-operator`.
 
 #### Decision
 
-**NOT DECIDED YET**
+`6.a` is selected.
 
 
 ### 7. Where to put the credentials
@@ -153,6 +153,10 @@ We can put the secret into customers' git repositories. Customers will access to
 #### 7.b Management Cluster Fleet
 
 We can put the secret into our `management-clusters-fleet` repo. We will need to give reference to that secret in customers' git repository. Management of these secrets can be so costly when we need to create the secret in each organization namespace.
+
+#### 7.c Catalog configuration
+
+We can use catalog configurations (See <mc-name>/appcatalog folder in `installations` repo) to provide a MC specific configuration to all charts in the cluster.
 
 #### Decision
 

--- a/container-registry-configuration/README.md
+++ b/container-registry-configuration/README.md
@@ -108,7 +108,7 @@ Since we use `containerd`, docker has not a privilege anymore but there is no ne
 - 4.a Giantswarm Account + Single account
 - 4.b Giantswarm Account + Per MC including its WCs
 - 4.c Giantswarm Account + Per WC
-- 4.b Customer Accounts
+- 4.d Customer Accounts
 
 #### Decision
 

--- a/container-registry-configuration/README.md
+++ b/container-registry-configuration/README.md
@@ -18,7 +18,7 @@ explicit k8s.gcr.io 12
 
 - We don't configure our Kubernetes clusters for container registries via a central configuration. We mostly rely on public registries and anonymous users. Some applications consume `.dockerConfigJson` from config repo but it is for only `quay.io`.
 
-- We have an infranet page (See `Registry Mirrors`) that states some decisions about which registries we must use. Shortly,
+- We have an intranet page (See `Registry Mirrors`) that states some decisions about which registries we must use. Shortly,
   - We need registry mirrors for high availability.
   - We will not run our own registy.
   - We will use `docker.io` as primary public registry since it has a privilege in docker daemon.
@@ -97,11 +97,11 @@ We will use authenticated accounts.
 
 ### 3. Registries
 
-The infranet page (See `Registry Mirrors`) states this as a desired configuration:
+The intranet page (See `Registry Mirrors`) states this as a desired configuration:
   - `docker.io` as primary public registry since it has a privilege in docker daemon.
   - Our own Azure Container Registry as secondary registry because of the security concerns
 
-Since we use `containerd`, docker has not a privelege anymore but there is no need to change this order at the moment. We will follow this configuration for CAPI clusters too.
+Since we use `containerd`, docker has not a privilege anymore but there is no need to change this order at the moment. We will follow this configuration for CAPI clusters too.
 
 ### 4. Accounts
 
@@ -114,7 +114,7 @@ Since we use `containerd`, docker has not a privelege anymore but there is no ne
 
 `4.b` is selected.
 
-Since it is a part of the platform itself, we are going to use GiantSwarm accounts in containerd configuration.
+Since it is a part of the platform itself, we are going to use Giant Swarm accounts in containerd configuration.
 As we do for other operators, we will follow "per MC" approach here to.
 
 ### 5. How to provide credentials to WCs

--- a/container-registry-configuration/README.md
+++ b/container-registry-configuration/README.md
@@ -140,7 +140,7 @@ We can put the secret into customers' git repositories and use GitOps templates 
 
 #### 6.c Management Cluster Fleet
 
-We can put the secret into our `management-clusters-fleet` repo. We will need to give reference to that secret in customers' git repository.
+We can put the secret into our `management-clusters-fleet` repo and refer that secret in `extraConfigs` in cluster apps. We can use GitOps templates to inject this configuration in all cluster apps.
 
 #### 6.d Catalog configuration
 
@@ -148,12 +148,11 @@ We can use catalog configurations (See <mc-name>/appcatalog folder in `installat
 
 #### Decision
 
-`6.d` is selected.
+`6.c` is selected.
 
 - Regarding 6.a, we don't want to add another responsility to `cluster-apps-operator`. 
 - Regarding 6.b, we want to manage the credentials in our side and to have a full control over them.
-- Regarding 6.c, management of the secrets can be so costly when we need to create the secret in each organization namespace.
-- Regarding 6.d, it is not the ideal solution we want to have since catalog configurations are hard to track. Nevertheless, we decided to start with this. Since the configurations are passed by the app platform, we can change this in the future without changing anything in cluster-$provider apps and users' inputs.
+- Regarding 6.d, people think catalog configurations are hard to track since there is no references in app CRs.
 
 ### 7. Configuration interface
 

--- a/container-registry-configuration/README.md
+++ b/container-registry-configuration/README.md
@@ -169,19 +169,19 @@ How will be the configuration interface in `cluster-$provider` apps?
 
 We can implement a full transitive configuration interface so that users can provide a full containerd configuration, including registy credentials.
 
-#### 8.b Only registry credentials in a structred way
+#### 8.b Only registry configuration in a structred way
 
 We can define a configuration interface like below and render containerd configuration in `cluster-$provider` app chart.
 
 ```
-registries:
-- name: docker
-  endpoint: https://registry-1.docker.io
-  username:
-  password:
-- name: azurecr
-  endpoint: giantswarm.azurecr.io
-  ...
+connectivity:
+ containerRegistries:
+   docker.io: 
+    - endpoint: "registry-1.docker.io"
+       credentials:
+         username: "my_user_name"
+         password: "my_password"
+   - endpoint: "my-mirror-registry.mydomain.io"
 ```
 
 #### Decision

--- a/container-registry-configuration/README.md
+++ b/container-registry-configuration/README.md
@@ -1,0 +1,123 @@
+# Container Registry Configuration
+
+The purpose of this RFC is to specify how we configure Kubernetes clusters for container registries.
+
+## Problem Statement
+
+Docker Hub has [download rate limit](https://docs.docker.com/docker-hub/download-rate-limit/) and it is pretty strict. To use Docker Hub without authentication is not a livable option for us. We started to hit the limit in big CAPI clusters during upgrades.
+
+## Current status
+
+- We use images from different registries. Here is the summary of registry usage of a test MC.
+```
+explicit docker.io  40
+implicit docker.io  2
+explicit quay.io    26
+explicit k8s.gcr.io 12
+```
+
+- We don't configure our Kubernetes clusters for container registries via a central configuration. We mostly rely on public registries and anonymous users. Some applications consume `.dockerConfigJson` from config repo but it is for only `quay.io`.
+
+- We have an infranet page (See `Registry Mirrors`) that states some decisions about which registries we must use. Shortly,
+  - We need registry mirrors for high availability.
+  - We will not run our own registy.
+  - We will use `docker.io` as primary public registry since it has a privilege in docker daemon.
+  - We will not use any other public registry (e.g. `quay.io`) as secondary registry because of some security concerns.
+  - We will use our own Azure Container Registry as secondary registry.
+
+- In vintage, we configure [containerd for docker registry mirrors](https://github.com/giantswarm/giantnetes-terraform/blob/13700c6d1b1adf8d65fba8b1b37eccf31e1ce4f3/templates/files/conf/containerd-config.toml#L37). 
+  
+## Possible solutions
+
+
+### ImagePullSecret
+
+We can set `imagePullSecrets` for all pods with an admission hook for authentication but Kubernetes doesn't have any mechanism like registry mirrors. That is why it is not a viable option.
+
+### FairwindsOps/saffire
+
+There is an open-source project to patch pods in `imagePullErrors` error state: https://github.com/FairwindsOps/saffire
+
+You are able to define alternative source for an image with a Custom Resource.
+
+```
+apiVersion: saffire.fairwinds.com/v1alpha1
+kind: AlternateImageSource
+metadata:
+  name: alternateimagesource-sample
+spec:
+  imageSourceReplacements:
+    - equivalentRepositories:
+        - quay.io/gianswarm/our-image
+        - azurecr.io/giantswarm/our-image
+        - docker.io/giantswarm/our-image
+```
+
+This mechanism doesn't work for static pods and it doesn't prevent the issue in advance. Also, it has no built-in mechanism for authentication. We can extend it or combine with the image pull secret solution but it sounds too complicated and dirty.
+
+
+### Containerd Configuration
+
+As we do in vintage clusters, we can configure containerd configuration as below. This seems the best approach.
+
+```
+[plugins."io.containerd.grpc.v1.cri".registry]
+
+[plugins."io.containerd.grpc.v1.cri".registry.mirrors]
+[plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
+endpoint = ["giantswarm.azurecr.io"]
+
+[plugins."io.containerd.grpc.v1.cri".registry.configs]
+[plugins."io.containerd.grpc.v1.cri".registry.configs."registry-1.docker.io".auth]
+username = "giantswarm-user-account"
+password = "my_token_from_docker_hub"
+```
+
+## Registry usage
+
+### Which registry should we use? 
+
+The infranet page (See `Registry Mirrors`) states this as a desired configuration:
+  - `docker.io` as primary public registry since it has a privilege in docker daemon.
+  - Our own Azure Container Registry as secondary registry because of the security concerns
+
+Using only public images without authentication is also on the table. In that case, we will be limited by total of [free account limit](https://docs.docker.com/docker-hub/download-rate-limit/) of Docker Hub (100 pulls per 6 hours per IP address) and [tier limit](https://learn.microsoft.com/en-us/azure/container-registry/container-registry-skus) of Azure Container Registry (3000 ReadOps per minute for standard). However, anyone can pull images from our registry and spend our limits, which makes us vulnerable. That is why we must use authenticated users.  
+
+### Open Points
+
+## How are we going to configure containerd in cluster app?
+
+We need to provide a configation interface in our `cluster-$provider` apps for the users so that they can provide their credentials. Note that we are the users of our management clusters.
+
+Options:
+1. We can ask users to create whole containerd configuration as a secret.
+2. We can ask users to provide list of registries and credentials as a secret and render containerd configuration with them.
+
+```
+registries:
+- name: docker
+  endpoint: https://registry-1.docker.io
+  username:
+  password:
+- name: azurecr
+  endpoint: giantswarm.azurecr.io
+  ...
+```
+
+> Note that there can be more than one feature we will support that affects containerd configuration like proxy settings. In this case, we should ensure that the option 1 will not lead conflicts.
+
+### Workload Clusters
+
+- Will we configure workload clusters by default?
+- Will we use our credentials for workload clusters by default?
+
+According to the discussion in Kaas Sync, we will configure management clusters and all workload clusters in the management cluster will inherit the configuration from their MCs.
+
+### Configuration Details
+
+- Where will be the source of truth for the container registry configuration? `config` repo or `management-cluster-fleet`?
+- How will WCs consume the credentials in their charts? 
+
+### How are going to manage credentials per cluster?
+
+Will we create a user per management cluster?

--- a/container-registry-configuration/README.md
+++ b/container-registry-configuration/README.md
@@ -103,6 +103,8 @@ The intranet page (See `Registry Mirrors`) states this as a desired configuratio
 
 Since we use `containerd`, docker has not a privilege anymore but there is no need to change this order at the moment. We will follow this configuration for CAPI clusters too.
 
+Also, users must be able to customize the configuration for their workload clusters. Additional registries and additional mirrors for existing registries must be supported.
+
 ### 4. Accounts
 
 - 4.a Giantswarm Account + Single account
@@ -117,59 +119,51 @@ Since we use `containerd`, docker has not a privilege anymore but there is no ne
 Since it is a part of the platform itself, we are going to use Giant Swarm accounts in containerd configuration.
 As we do for other operators, we will follow "per MC" approach here to.
 
-### 5. How to provide credentials to WCs
+### 5. Default configuration for WCs
 
-#### 5.a cluster-apps-operator
+- 5.a: Configuring WCs by default
+- 5.b: Not configuring WCs by default
+
+#### Decision
+
+`5.a` is selected.
+
+### 6. How to propogate credentials and where to put them
+
+#### 6.a cluster-apps-operator
 
 We can propogate credentials from MC to WC by using `cluster-apps-operator`. It can create a secret per WC with the credentials.
 
-#### 5.b Optional interface + Gitops
+#### 6.b Customer's Git Repository
 
-We can delegate the responsibility of creating credentials secret to the creator of `cluster-$provider` apps. GitOps can be useful to template the secrets per WC.
+We can put the secret into customers' git repositories and use GitOps templates to use the same credentials for all WCs. 
 
-#### Decision
+#### 6.c Management Cluster Fleet
 
-`5.b` is selected.
+We can put the secret into our `management-clusters-fleet` repo. We will need to give reference to that secret in customers' git repository.
 
-We don't want to add another responsility to `cluster-apps-operator`. 
-
-
-### 6. Default configuration for WCs
-
-- 6.a: Configuring WCs by default
-- 6.b: Not configuring WCs by default
-
-#### Decision
-
-`6.a` is selected.
-
-### 7. Where to put the credentials
-
-#### 7.a Customer's Git Repository
-
-We can put the secret into customers' git repositories. Customers will access to our credentials.
-
-#### 7.b Management Cluster Fleet
-
-We can put the secret into our `management-clusters-fleet` repo. We will need to give reference to that secret in customers' git repository. Management of these secrets can be so costly when we need to create the secret in each organization namespace.
-
-#### 7.c Catalog configuration
+#### 6.d Catalog configuration
 
 We can use catalog configurations (See <mc-name>/appcatalog folder in `installations` repo) to provide a MC specific configuration to all charts in the cluster.
 
 #### Decision
 
-7.c is selected.
+`6.d` is selected.
 
-### 8. Configuration interface
+- Regarding 6.a, we don't want to add another responsility to `cluster-apps-operator`. 
+- Regarding 6.b, we want to manage the credentials in our side and to have a full control over them.
+- Regarding 6.c, management of the secrets can be so costly when we need to create the secret in each organization namespace.
+- Regarding 6.d, it is not the ideal solution we want to have since catalog configurations are hard to track. Nevertheless, we decided to start with this. Since the configurations are passed by the app platform, we can change this in the future without changing anything in cluster-$provider apps and users' inputs.
+
+### 7. Configuration interface
 
 How will be the configuration interface in `cluster-$provider` apps?
 
-#### 8.a Full containerd configuration
+#### 7.a Full containerd configuration
 
 We can implement a full transitive configuration interface so that users can provide a full containerd configuration, including registy credentials.
 
-#### 8.b Only registry configuration in a structred way
+#### 7.b Only registry configuration in a structred way
 
 We can define a configuration interface like below and render containerd configuration in `cluster-$provider` app chart.
 
@@ -186,6 +180,6 @@ connectivity:
 
 #### Decision
 
-`8.b` is selected.
+`7.b` is selected.
 
-8.a seems risky. Also, there can be other configurations (e.g. proxy) that touch containerd configuration too. 8.a can be error prone.
+7.a seems risky. Also, there can be other configurations (e.g. proxy) that touch containerd configuration too. 7.a can be error prone.


### PR DESCRIPTION
This PR adds an RFC regarding how we want to manage container registry configuration for our clusters.

A reference implementation in cluster app: https://github.com/giantswarm/cluster-cloud-director/pull/79
Configuration of management clusters during bootstrap: https://github.com/giantswarm/mc-bootstrap/pull/429