### PR TITLE
Adapt existing RFCs to new structure, add script and CI pipeline to check structure

### DIFF
--- a/.github/rfc-format/check-rfc-format.py
+++ b/.github/rfc-format/check-rfc-format.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+# This checks the required RFC file format as described in https://github.com/giantswarm/rfc/tree/main/decision-process.
+# Also, for the purpose of rendering RFCs in our https://github.com/giantswarm/handbook, this script can output all RFCs
+# in a stable JSON format to a file so that the rendering script can use that information instead of writing the
+# parsing code twice.
+import argparse
+import datetime
+import difflib
+import json
+import os
+import re
+import sys
+
+import frontmatter
+import yaml  # used by frontmatter, so we can use exception types from here
+
+
+class RfcFormatProblems(RuntimeError):
+    def __init__(self, problems):
+        self.problems = problems
+
+
+ALLOWED_STATES = {
+    'approved',
+    'declined',
+    'obsolete',
+    'review',
+}
+FRONTMATTER_REQUIRED_KEYS = {
+    'creation_date',
+    'state',
+}
+FRONTMATTER_OPTIONAL_KEYS = {
+    'issues',  # to become required once all existing RFCs have it filled
+    'last_review_date',
+    'owners',  # to become required once all existing RFCs have it filled
+    'summary',  # to become required once all existing RFCs have it filled
+}
+FRONTMATTER_KEYS_BECOMING_REQUIRED = {
+    'issues',
+    'owners',
+    'summary',
+}
+FRONTMATTER_KEYS_BECOMING_REQUIRED_FROM_DATE = datetime.date(2023, 10, 12)
+FRONTMATTER_ALL_KEYS = FRONTMATTER_REQUIRED_KEYS | FRONTMATTER_OPTIONAL_KEYS
+GITHUB_OWNER_URL_REGEX = re.compile(
+    # Single GitHub user (not recommended since single-people ownership is doomed to fail)
+    r'^(https://github.com/[A-Za-z0-9][-A-Za-z0-9]*[A-Za-z0-9]'
+    # Alternative URL format for individual people, as found on a team page
+    r'|https://github.com/orgs/giantswarm/people/.+'
+    # Most preferred: reference to a team
+    r'|https://github.com/orgs/giantswarm/teams/.+)$')
+ISSUE_URL_REGEX = re.compile(
+    r'^(https://github.com/[A-Za-z0-9][-A-Za-z0-9]*[A-Za-z0-9]/[A-Za-z0-9][-A-Za-z0-9]*[A-Za-z0-9]/issues/[1-9][0-9]*$)'
+)
+OLD_RFC_NUMBER_IN_TITLE_REGEX = re.compile(r'RFC \d+\s*(-\s*)?')
+TRAILING_WHITESPACE_REGEX = re.compile(r'[ \t\v]+$', flags=re.MULTILINE)
+
+
+def check_rfc(rfc_dir):
+    readme_file_path = os.path.join(rfc_dir, 'README.md')
+    rfc = frontmatter.load(readme_file_path)
+    problems = []
+
+    if not rfc.metadata:
+        # No YAML header, so the file is completely wrong. Stop checking here.
+        problems.append(
+            'README.md requires a YAML header as specified at '
+            'https://github.com/giantswarm/rfc/tree/main/decision-process#decision-making-process')
+        raise RfcFormatProblems(problems)
+
+    unsupported_keys = set(rfc.metadata.keys()).difference(FRONTMATTER_ALL_KEYS)
+    if unsupported_keys:
+        problems.append(
+            'Front matter YAML header has unsupported keys (please read '
+            'https://github.com/giantswarm/rfc/tree/main/decision-process#rfc-file-structure): '
+            f'{", ".join(sorted(unsupported_keys))}')
+
+    missing_keys = FRONTMATTER_REQUIRED_KEYS.difference(rfc.metadata.keys())
+    if missing_keys:
+        problems.append(
+            'Front matter YAML header is missing these keys (please read '
+            'https://github.com/giantswarm/rfc/tree/main/decision-process#rfc-file-structure): '
+            f'{", ".join(sorted(missing_keys))}')
+
+    for date_key in ('creation_date', 'last_review_date'):
+        if date_key not in rfc.metadata:
+            continue
+
+        # The YAML parser used in the `frontmatter` library will automatically use this type if the date is correctly
+        # specified (format YYYY-MM-DD wanted)
+        if not isinstance(rfc.metadata[date_key], datetime.date):
+            problems.append(f'Front matter YAML header key "{date_key}" must be in format YYYY-MM-DD')
+        elif not (2021 <= rfc.metadata[date_key].year <= 2100):
+            problems.append(f'Front matter YAML header key "{date_key}" contains unexpected year')
+
+    if (isinstance(rfc.metadata.get('creation_date'), datetime.date)
+            and rfc.metadata['creation_date'] >= FRONTMATTER_KEYS_BECOMING_REQUIRED_FROM_DATE):
+        missing_keys_required_in_new_rfcs = FRONTMATTER_KEYS_BECOMING_REQUIRED.difference(rfc.metadata.keys())
+        if missing_keys_required_in_new_rfcs:
+            problems.append(
+                'Front matter YAML header is missing these keys (please read '
+                'https://github.com/giantswarm/rfc/tree/main/decision-process#rfc-file-structure): '
+                f'{", ".join(sorted(missing_keys_required_in_new_rfcs))}')
+
+    if 'state' in rfc.metadata and rfc.metadata['state'] not in ALLOWED_STATES:
+        problems.append(f'Front matter YAML header key "status" must be one of: {", ".join(sorted(ALLOWED_STATES))}')
+
+    if 'summary' in rfc.metadata:
+        rfc.metadata['summary'] = rfc.metadata['summary'].rstrip()
+        if not rfc.metadata['summary']:
+            problems.append(
+                '`summary` is empty. Please provide 1-3 concise sentences, without paragraphs, describing '
+                'the outcome/decision.')
+        elif '\n' in rfc.metadata['summary']:
+            problems.append(
+                '`summary` should be short, but uses paragraphs. Please provide 1-3 concise sentences, without '
+                'paragraphs, describing the outcome/decision.')
+
+    if 'owners' in rfc.metadata:
+        if not rfc.metadata['owners']:
+            problems.append(
+                'Front matter YAML header key "owners" must be a non-empty list (e.g. referencing one or more teams '
+                'in the form `https://github.com/orgs/giantswarm/teams/sig-architecture`)')
+
+        for owner in rfc.metadata['owners']:
+            if not GITHUB_OWNER_URL_REGEX.match(owner):
+                problems.append(
+                    'Front matter YAML header key "owners" must be a non-empty list (e.g. referencing one or more teams '
+                    'in the form `https://github.com/orgs/giantswarm/teams/sig-architecture`). Got invalid item: '
+                    f'{owner!r}')
+
+    # List of issues may be empty or null (not all decisions have a related issue)
+    if 'issues' in rfc.metadata:
+        if rfc.metadata['issues'] is not None and not isinstance(rfc.metadata['issues'], (tuple, list)):
+            problems.append(
+                'Front matter YAML header key "issues" must be a list of GitHub issue URLs or an empty list '
+                '(NULL also allowed but not recommended)')
+
+        for issue_url in (rfc.metadata['issues'] or ()):
+            if not ISSUE_URL_REGEX.match(issue_url):
+                problems.append(
+                    'Front matter YAML header key "issues" must be a list of GitHub issue URLs or an empty list '
+                    '(NULL also allowed but not recommended). Got invalid item: '
+                    f'{issue_url!r}')
+
+    with open(readme_file_path) as f:
+        actual = f.read()
+
+    actual_whitespace_trimmed = TRAILING_WHITESPACE_REGEX.sub('', actual)
+    if actual_whitespace_trimmed != actual:
+        diff_whitespace = ''.join(difflib.unified_diff(
+            actual.splitlines(True),
+            actual_whitespace_trimmed.splitlines(True),
+            fromfile=readme_file_path,
+            tofile=f'{readme_file_path}.no-trailing-whitespace',
+            n=0,
+        ))
+        problems.append(
+            'README.md must not have any trailing whitespace. Please configure your editor to always trim '
+            'trailing whitespace in Markdown files.\n\n'
+            'These are the affected lines:\n\n'
+            f'{diff_whitespace}')
+
+    if 'issues' in rfc.metadata and rfc.metadata['issues'] is None:
+        # Prefer empty list when printing a patch diff below
+        rfc.metadata['issues'] = []
+    expected = frontmatter.dumps(
+        rfc,
+        # We want the front matter YAML header keys to be sorted alphabetically
+        sort_keys=True,
+        # Don't wrap long lines such as `summary: Sentence 1. Sentence 2. Sentence 3.` but keep them on one line.
+        # It would be annoying to ask from authors to get the exact line wrapping length correct or update their PR
+        # just because of some text wrapping differences.
+        width=1000,
+    ).rstrip('\n') + '\n'  # want exactly one newline at end of file
+
+    # Show diff without trailing whitespace since that was already checked above
+    expected = TRAILING_WHITESPACE_REGEX.sub('', expected)
+
+    diff = ''.join(difflib.unified_diff(
+        actual_whitespace_trimmed.splitlines(True),
+        expected.splitlines(True),
+        fromfile=readme_file_path,
+        tofile=f'{readme_file_path}.patched',
+    ))
+    if diff:
+        problems.append(f'Formatted output is different.\n\nPlease apply this patch:\n{diff}')
+
+    # Find title (first H1 heading)
+    markdown_content_lines = rfc.content.splitlines()
+    for title_line_index, line in enumerate(markdown_content_lines):
+        if line.startswith('# '):
+            title = line[len('# '):].strip()
+
+            # Some RFCs were titled after their GitHub PR number, but we didn't enforce such a numbering. Discard that part.
+            title = OLD_RFC_NUMBER_IN_TITLE_REGEX.sub('', title)
+
+            rfc.metadata['title'] = title
+            rfc.metadata['markdown_content_without_title'] = (
+                '\n'.join(markdown_content_lines[title_line_index + 1:]).lstrip().rstrip('\n') + '\n')
+
+            break
+        elif line.strip():
+            problems.append(
+                'Could not find title, or it was not the very first non-empty line after the YAML header. Please add '
+                'a H1 heading (e.g. `# This is my RFC title`) directly after the YAML header. '
+                f'Problematic line: {line!r}')
+            break
+    else:
+        problems.append(
+            'Could not find title. Please add a H1 heading (e.g. `# This is my RFC title`) after the YAML header.')
+
+    if problems:
+        raise RfcFormatProblems(problems)
+
+    return rfc
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('rfc_repo_dir', help='Path to Git clone of https://github.com/giantswarm/rfc')
+    parser.add_argument(
+        '-o',
+        '--output',
+        help=(
+            'If specified, all RFCs will be stored in this file, using a rather stable JSON format. '
+            'Use `-` to output on stdout.'
+        ))
+    args = parser.parse_args()
+
+    res = 0
+    rfcs_json = []  # sorted in alphabetical order of directory names
+
+    for entry_name in sorted(os.listdir(args.rfc_repo_dir)):
+        # Each RFC is expected in a top-level directory, containing the main file `README.md`
+        rfc_dir = os.path.join(args.rfc_repo_dir, entry_name)
+        if not os.path.isdir(rfc_dir):
+            continue
+        readme_file_path = os.path.join(rfc_dir, 'README.md')
+        if not os.path.exists(readme_file_path):
+            continue
+
+        try:
+            rfc = check_rfc(rfc_dir)
+
+            # Right now, this output only provides values relevant for rendering a table/summary of the RFCs
+            # in the handbook.
+            rfcs_json.append({
+                'creation_date': rfc.metadata['creation_date'].isoformat(),
+                'markdown_content_without_title': rfc.metadata['markdown_content_without_title'],
+                'slug': entry_name,
+                'state': rfc.metadata['state'],
+                'summary': rfc.metadata.get('summary'),
+                'title': rfc.metadata['title'],
+            })
+        except RfcFormatProblems as e:
+            problems_str = '\n\n'.join(f'- {problem}' for problem in e.problems)
+            print(f'Format problems in "{rfc_dir}":\n\n{problems_str}\n', file=sys.stderr)
+            res = 1
+        except Exception as e:
+            if isinstance(e, yaml.YAMLError):
+                e = (
+                    f'Front matter is not a valid YAML header. The error was: {e}'
+                    # Replace hint in the error message so the author knows in which file/line/column to look
+                    .replace('in "<unicode string>", line', f'in "{readme_file_path}", line')
+                )
+
+            print(f'Error in "{rfc_dir}":\n\n{e}\n', file=sys.stderr)
+            res = 1
+
+    if res:
+        print(
+            'Please read the decision process https://github.com/giantswarm/rfc/tree/main/decision-process to learn '
+            'about the expected file structure.',
+            file=sys.stderr)
+
+    if res == 0 and args.output is not None:
+        out = open(args.output, 'w') if args.output != '-' else sys.stdout
+        try:
+            json.dump(rfcs_json, out, sort_keys=True, indent=4)
+            out.write('\n')
+        finally:
+            if args.output != '-':
+                out.close()
+
+    return res
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/.github/rfc-format/requirements.txt
+++ b/.github/rfc-format/requirements.txt
@@ -1,0 +1,1 @@
+python-frontmatter==1.0.1

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -1,0 +1,25 @@
+name: Validate
+on:
+  push: {}
+jobs:
+  apply:
+    name: Check RFCs
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: Setup python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.12
+
+      - name: Install dependencies
+        run: |
+          python -m pip install -r .github/rfc-format/requirements.txt
+
+      - name: Check RFCs format
+        run: |
+          .github/rfc-format/check-rfc-format.py -o /tmp/rfc-output.json .
+
+          [ -s /tmp/rfc-output.json ] || { echo "RFC JSON output is empty - please check that the script still works"; exit 1; }

--- a/README.md
+++ b/README.md
@@ -1,35 +1,19 @@
 # rfc
 
-This describes the RFC process for Giant Swarm.
+## Rationale
 
-Giant Swarm is a growing, distributed company, and we want to ensure that everyone continues to have the ability to bring their ideas and thoughts into the hivemind. While a large amount of our discussion currently happens successfully in chats and calls, a long-form writing process may provide some benefits: i.e: promoting deep thinking and discussion, creating a record of considered ideas and discussion, reducing number of meetings (and allowing easier management of timezones), and providing avenues for increasing the asynchronicity of our work.
+Giant Swarm is a growing, distributed company, and we want to ensure that everyone continues to have the ability to bring their ideas and thoughts into the hivemind. While a large amount of our discussion currently happens successfully in chats and calls, a long-form writing process provides some benefits, for example: promoting deep thinking and discussion, creating a record of considered ideas and discussion, reducing number of meetings (and allowing easier management of timezones), and providing avenues for increasing the asynchronicity of our work.
 
 Before scheduling a call, or starting a Slack thread, ask yourself whether you could be writing an RFC instead.
 
 All ideas, thoughts, comments, suggestions, and eldritch ramblings, are valid and welcomed as RFCs.
 
-## Housekeeping
+## Process
 
-The following lists some basic formatting and housekeeping decisions concerning RFCs:
+This repo contains RFCs of Giant Swarm. Please read the [RFC and decision making process](./decision-process) (which itself is an RFC) for how Markdown formatting, creation, discussion and approval/decline works.
 
-- Each RFC must be in its own directory, with the directory name in the form `$title`.
-- The main RFC filename within the directory should be in the form of `README.md`. This enables a preview on Github.
-- RFCs must be written in Markdown.
+When linking to an RFC, please use the [rendered list of RFCs in the handbook](https://handbook.giantswarm.io/docs/rfcs/). Please refrain from treating PR numbers as "RFC number", since we don't have such an identifier. The directory name of an RFC should stay unchanged since it's a permanent part of handbook/GitHub links to the document.
 
-The following lists some ideas towards RFC that are explicitly not presented:
+## Visibility
 
-- No formal structure (i.e: headers) is presented.
-- No lifecycle (i.e: different stages of discussion or acceptance) is presented. This includes GitHub process - RFCs can be discussed as much as wanted in Pull Requests, and then merged as the author(s) see fit.
-- No changes to ADRs or PDRs are presented.
-- No minimum or maximum limits on size of RFCs are presented.
-
-This is both to allow a more natural process to evolve over time, as well as to not prescribe a badly-fitting process too early. The above points could be the subject of future RFCs.
-
-## Visiblity
-
-The RFC repository (`giantswarm/rfc`) is public. This is a continuation of Giant Swarm's default position of radical transparency, with the aim to allow all ideas to be shared and discussed openly. Some reasonable efforts may need to be made to ensure sensitive information remains private.
-
-## Sources
-
-- [IETF, RFC 3](https://tools.ietf.org/html/rfc3)
-- [Oxide Computer Company, RFD 1](https://oxide.computer/blog/rfd-1-requests-for-discussion/)
+This repository (`giantswarm/rfc`) is public. This is a continuation of Giant Swarm's default position of radical transparency, with the aim to allow all ideas to be shared and discussed openly. Some reasonable efforts may need to be made to ensure sensitive information remains private.

--- a/alias-forwarder-email-service/README.md
+++ b/alias-forwarder-email-service/README.md
@@ -1,3 +1,8 @@
+---
+creation_date: 2022-02-15
+state: approved
+---
+
 # A better customer email management solution
 
 This RFC investigates ways for managing (urgent) requests from customers received via email.
@@ -16,7 +21,7 @@ We would like to be able to configure email aliases (where *alias*="some smart w
 
 For instance, some emails (`urgent`) could be redirected to Opsgenie, while others (`support`) could be redirected to Slack.
 
-A possible format could be the following: `customer-priority-area@giantswarm.io`. This would allow us to correctly address an email received from e.g. `adidas-urgent-aws@giantswarm.io` vs. `vodafone-support-security@giantswarm.io`. 
+A possible format could be the following: `customer-priority-area@giantswarm.io`. This would allow us to correctly address an email received from e.g. `adidas-urgent-aws@giantswarm.io` vs. `vodafone-support-security@giantswarm.io`.
 
 ## Questions to answer
 
@@ -102,7 +107,7 @@ Considering the pros and cons of each solution and the number of comments receiv
     - `kvm`
     - `openstack`
     - `vmware`
-  
+
   Cloud native packs:
     - `devex`
     - `connectivity`

--- a/automatic-app-upgrades/README.md
+++ b/automatic-app-upgrades/README.md
@@ -1,3 +1,8 @@
+---
+creation_date: 2022-04-15
+state: approved
+---
+
 # Automatic App upgrades
 
 ## Solution proposal

--- a/automatic-cluster-upgrades/README.md
+++ b/automatic-cluster-upgrades/README.md
@@ -1,3 +1,8 @@
+---
+creation_date: 2021-09-17
+state: approved
+---
+
 # RFC 0015 - Automatic workload cluster upgrades
 
 ## Resources
@@ -38,7 +43,7 @@ Based on the fact Giant Swarm is moving to Cluster API this is story let us defi
 
 ### Cluster upgrade entity
 
-There are different reason why we are interested in having an object to define the upgrade intent. 
+There are different reason why we are interested in having an object to define the upgrade intent.
 
 - As we define in the user stories, we/customers would like to schedule upgrades on certain date from running version to a specific one. That way customer can plan upgrades ahead and so do we.
 
@@ -52,7 +57,7 @@ There are different reason why we are interested in having an object to define t
 
 Our customer can have a different set of constraints when it comes to allow changes in their clusters. The maintenance schedule would define those and then the clusters can rely on a policy to enforce the desired behavior.
 
-The maintenance schedule would be reconciled by the cluster upgrade scheduler and it will program the upgrades based on that restrictions. 
+The maintenance schedule would be reconciled by the cluster upgrade scheduler and it will program the upgrades based on that restrictions.
 
 The maintenance schedule would contain
 
@@ -71,7 +76,7 @@ We envision aforementioned concepts would become custom resource definitions and
 Example resource:
 
 ```yaml
-apiVersion: 
+apiVersion:
 kind: ClusterUpgrade
 metadata:
   name: upgrade-to-cluster-openstack-v1.20
@@ -104,7 +109,7 @@ status:
 Example resource:
 
 ```yaml
-apiVersion: 
+apiVersion:
 kind: MaintenanceSchedule
 metadata:
   name: working-hours-except-month-start
@@ -128,7 +133,7 @@ This would allow upgrades to happen between 07:00 UTC and 17:00 UTC on Monday-Fr
 
 #### Cluster upgrade executor
 
-There will be an operator that based on the `Cluster Upgrade` CRs will trigger the upgrades changing the labels on the specific CR(s) when date matches or it will create the pull requests in Git repo to trigger the upgrade (Flux controllers could be used here for that). 
+There will be an operator that based on the `Cluster Upgrade` CRs will trigger the upgrades changing the labels on the specific CR(s) when date matches or it will create the pull requests in Git repo to trigger the upgrade (Flux controllers could be used here for that).
 
 This operator can also check on the `maintenance schedule` to verify the upgrade fulfil or not the criteria, and in case it does not, alert or set an appropriate status on the object status.
 

--- a/cabbage-roadmap-2022-1/README.md
+++ b/cabbage-roadmap-2022-1/README.md
@@ -1,3 +1,8 @@
+---
+creation_date: 2022-04-07
+state: approved
+---
+
 # Team Cabbage Roadmap 2022
 
 This RFC describes the roadmap for Team Cabbage for the first part of 2022.
@@ -8,7 +13,7 @@ Since the formation of Team Cabbage just after the Croatia onsite (~September 20
 
 This involved the usual work for team formation, including defining Jobs To Be Done and overall mission statement. We had a number of issues to clean up or sort out, such as dissolving Team Halo, postmortems, and app upgrades. We also updated the monitoring and alerting for our apps.
 
-Finally, we continued improving our support for shipping Kong as a Managed App, and shipped the AWS LB Controller as a Managed App. 
+Finally, we continued improving our support for shipping Kong as a Managed App, and shipped the AWS LB Controller as a Managed App.
 
 ## Jobs To Be Done
 

--- a/capi-adoption/README.md
+++ b/capi-adoption/README.md
@@ -1,3 +1,8 @@
+---
+creation_date: 2021-07-19
+state: approved
+---
+
 # Road to Cluster API (over the potholes)
 
 ## About

--- a/capi-configuration/README.md
+++ b/capi-configuration/README.md
@@ -1,3 +1,8 @@
+---
+creation_date: 2021-11-10
+state: approved
+---
+
 # Configuration management with Cluster API
 
 This RFC describes how we can handle configuration management with Cluster API - focusing on defaulting, upgrades and interactions.

--- a/classify-cluster-priority/README.md
+++ b/classify-cluster-priority/README.md
@@ -1,3 +1,8 @@
+---
+creation_date: 2022-05-11
+state: approved
+---
+
 # Classifying clusters based on priority
 
 Contents:

--- a/container-registry-configuration/README.md
+++ b/container-registry-configuration/README.md
@@ -1,3 +1,8 @@
+---
+creation_date: 2023-03-01
+state: approved
+---
+
 # Container Registry Configuration
 
 The purpose of this RFC is to specify how we configure Kubernetes clusters for container registries.
@@ -25,8 +30,8 @@ explicit k8s.gcr.io 12
   - We will not use any other public registry (e.g. `quay.io`) as secondary registry because of some security concerns.
   - We will use our own Azure Container Registry as secondary registry.
 
-- In vintage, we configure [containerd for docker registry mirrors](https://github.com/giantswarm/giantnetes-terraform/blob/13700c6d1b1adf8d65fba8b1b37eccf31e1ce4f3/templates/files/conf/containerd-config.toml#L37). 
-  
+- In vintage, we configure [containerd for docker registry mirrors](https://github.com/giantswarm/giantnetes-terraform/blob/13700c6d1b1adf8d65fba8b1b37eccf31e1ce4f3/templates/files/conf/containerd-config.toml#L37).
+
 ## Design proposals
 
 ### 1. How to solve ImagePullErrors
@@ -77,13 +82,13 @@ password = "my_token_from_docker_hub"
 #### Decision
 
 `1.c` is selected.
-We will use containerd configuration. 
+We will use containerd configuration.
 
 ### 2. Authentication
 
 #### 2.a Using unauthenticated accounts
 
-Using only public images without authentication is an option to avoid complexity of securing credentials. However, registry providers have pull/rate limits per account. We will be limited by total of [free account limit](https://docs.docker.com/docker-hub/download-rate-limit/) of Docker Hub (100 pulls per 6 hours per IP address) and [tier limit](https://learn.microsoft.com/en-us/azure/container-registry/container-registry-skus) of Azure Container Registry (3000 ReadOps per minute for standard). Anyone can pull images from our registry and spend our limits, which makes us vulnerable. 
+Using only public images without authentication is an option to avoid complexity of securing credentials. However, registry providers have pull/rate limits per account. We will be limited by total of [free account limit](https://docs.docker.com/docker-hub/download-rate-limit/) of Docker Hub (100 pulls per 6 hours per IP address) and [tier limit](https://learn.microsoft.com/en-us/azure/container-registry/container-registry-skus) of Azure Container Registry (3000 ReadOps per minute for standard). Anyone can pull images from our registry and spend our limits, which makes us vulnerable.
 
 #### 2.b Using authenticated accounts
 
@@ -136,7 +141,7 @@ We can propogate credentials from MC to WC by using `cluster-apps-operator`. It 
 
 #### 6.b Customer's Git Repository
 
-We can put the secret into customers' git repositories and use GitOps templates to use the same credentials for all WCs. 
+We can put the secret into customers' git repositories and use GitOps templates to use the same credentials for all WCs.
 
 #### 6.c Management Cluster Fleet
 
@@ -150,7 +155,7 @@ We can use catalog configurations (See <mc-name>/appcatalog folder in `installat
 
 `6.c` is selected.
 
-- Regarding 6.a, we don't want to add another responsility to `cluster-apps-operator`. 
+- Regarding 6.a, we don't want to add another responsility to `cluster-apps-operator`.
 - Regarding 6.b, we want to manage the credentials in our side and to have a full control over them.
 - Regarding 6.d, people think catalog configurations are hard to track since there is no references in app CRs.
 
@@ -169,7 +174,7 @@ We can define a configuration interface like below and render containerd configu
 ```
 connectivity:
  containerRegistries:
-   docker.io: 
+   docker.io:
     - endpoint: "registry-1.docker.io"
        credentials:
          username: "my_user_name"

--- a/crossplane-capi-import/README.md
+++ b/crossplane-capi-import/README.md
@@ -1,3 +1,12 @@
+---
+creation_date: 2023-10-26
+issues: []
+owners:
+- https://github.com/orgs/giantswarm/teams/wg-cluster-api
+state: approved
+summary: 'In order for Giant Swarm to import/adopt customer clusters on bring-your-own infrastructure, use Crossplane `ObserveOnly` functionality for resources to discover existing infrastructure of customers without managing it. Use `clusters.x-k8s.io/managed-by: crossplane` annotation to prevent CAPI from reconciling clusters. Do not rely on "paused" objects.'
+---
+
 # Importing EKS/AKS/GKE clusters to CAPI using crossplane
 
 ## Introduction

--- a/crossplane/README.md
+++ b/crossplane/README.md
@@ -1,3 +1,8 @@
+---
+creation_date: 2022-11-09
+state: approved
+---
+
 # Crossplane MVP on Management Clusters
 
 Managed Crossplane offering is under development as per customers' requests.

--- a/decision-process/README.md
+++ b/decision-process/README.md
@@ -1,12 +1,13 @@
 ---
 creation_date: 2023-10-10
 issues:
-  - https://github.com/giantswarm/giantswarm/issues/24661
+- https://github.com/giantswarm/giantswarm/issues/24661
 owners:
-  - https://github.com/orgs/giantswarm/teams/sig-architecture
-  - https://github.com/orgs/giantswarm/teams/team-horizon
-  - https://github.com/orgs/giantswarm/teams/team-team
-state: review
+- https://github.com/orgs/giantswarm/teams/sig-architecture
+- https://github.com/orgs/giantswarm/teams/team-horizon
+- https://github.com/orgs/giantswarm/teams/team-team
+state: approved
+summary: This contains the explicit procedure to follow for creating an RFC and having it reviewed. Introduce a structured YAML header for the Markdown file. List of RFCs gets rendered in the handbook.
 ---
 
 # RFC and decision making process
@@ -34,11 +35,11 @@ To allow for a decision making process without removing the current free-form na
 The following changes will be introduced:
 
 - All RFCs will have a YAML header with structured information that can be parsed and used e.g. for rendering the RFCs in our [handbook](https://handbook.giantswarm.io/)
-- The YAML header must contain the following fields in this order:
+- The YAML header must contain the following fields in alphabetical order:
 
   - `creation_date: YYYY-MM-DD`
   - `issues` containing links to GitHub issues. Can be null or an empty list. The issues can be the origin of the RFC or where the work for implementing the decision takes place.
-  - `owners` containing GitHub team URLs. This list must not be empty. Please enter only the team and/or SIG names of the author and owners, not the teams who should comment on the RFC (the _stakeholders_, for which we don't have a structured field). The `owners` field contains teams who have the expertise to check the RFC after a few months. It may later be used to automatically create GitHub issues "Please review if this RFC is still relevant" (see [Future ideas](#future-ideas)).
+  - `owners` containing GitHub team URLs. This list must not be empty. Please enter only the team and/or SIG names of the author and owners, not the teams who should comment on the RFC (the _stakeholders_, for which we don't have a structured field). The `owners` field contains teams who have the expertise to check the RFC after a few months. It may later be used to automatically create GitHub issues "Please review if this RFC is still relevant" (see [Future ideas](#future-ideas)). Single person URLs (`https://github.com/TheUsername`) are allowed but not recommended.
   - `state` having one of the values
 
     - `review` – The RFC pull request is in review and waiting for comments. The decision is not in effect.
@@ -56,9 +57,9 @@ The following is an entire and valid start of an RFC markdown file:
 ---
 creation_date: 2023-07-13
 issues:
-  - https://github.com/giantswarm/giantswarm/issues/24661
+- https://github.com/giantswarm/giantswarm/issues/24661
 owners:
-  - https://github.com/orgs/giantswarm/teams/team-horizon
+- https://github.com/orgs/giantswarm/teams/team-horizon
 state: review
 ---
 
@@ -83,9 +84,9 @@ Therefore, we will automatically render the merged RFCs into our [handbook](http
     ---
     creation_date: YYYY-MM-DD # please fill this in
     issues:
-      - https://github.com/giantswarm/giantswarm/issues/FILL_IN_YOUR_ISSUE
+    - https://github.com/giantswarm/giantswarm/issues/FILL_IN_YOUR_ISSUE
     owners:
-      - https://github.com/orgs/giantswarm/teams/team-FILL_IN_YOUR_TEAM # or https://github.com/orgs/giantswarm/teams/sig-FILL_IN_YOUR_SIG
+    - https://github.com/orgs/giantswarm/teams/team-FILL_IN_YOUR_TEAM # or https://github.com/orgs/giantswarm/teams/sig-FILL_IN_YOUR_SIG
     state: review
     ---
 

--- a/defaulting-capi-clusters/README.md
+++ b/defaulting-capi-clusters/README.md
@@ -1,3 +1,8 @@
+---
+creation_date: 2021-07-23
+state: approved
+---
+
 # Defaulting of CAPI clusters with webhooks
 
 This RFC describes a pattern for defaulting of CAPI clusters by utilizing Kubernetes webhooks extensively.

--- a/giantswarm-crd-managmenet-via-flux-extension/README.md
+++ b/giantswarm-crd-managmenet-via-flux-extension/README.md
@@ -1,10 +1,15 @@
+---
+creation_date: 2023-08-24
+state: approved
+---
+
 # Extension to Giant Swarm CRD management via Flux
 
 Related to: [Manage essential CRDs via MCB](../manage-essential-crds-via-mcb/README.md)
 
 ## Context
 
-The original solution does not leave room for provider specific resources in the sense that all `crds` 
+The original solution does not leave room for provider specific resources in the sense that all `crds`
 Flux kustomization reconciles CMC `bases/crds` meaning all management clusters in the given CMC will
 have the same set of CRDs installed. (Note, that with the current solution we need to have a file in the CMC
 that is pointed to by the `crds` kustomization because the flux source is the CMC repository and from there

--- a/gitops-management-clusters/README.md
+++ b/gitops-management-clusters/README.md
@@ -1,3 +1,8 @@
+---
+creation_date: 2021-07-12
+state: approved
+---
+
 # RFC 0002 - Enable customers to use gitops in management clusters
 
 We currently give customers access to the management clusters but do not support them in utilizing this access effectively in terms of git ops related management (e.g. for apps).

--- a/installation-names/README.md
+++ b/installation-names/README.md
@@ -1,3 +1,8 @@
+---
+creation_date: 2022-09-07
+state: approved
+---
+
 # Assigning installation names
 
 The purpose of this RFC is to specify how we select installation names.

--- a/kyverno-policy-deployment/README.md
+++ b/kyverno-policy-deployment/README.md
@@ -1,3 +1,8 @@
+---
+creation_date: 2022-03-24
+state: approved
+---
+
 # RFCs Related to Kyverno Policy Management and Deployment
 
 - [Handling Kyverno Policy Deployment][policy-deployment] details the repository structure used for storing Kyverno policies

--- a/kyverno-pss-policy-exceptions/README.md
+++ b/kyverno-pss-policy-exceptions/README.md
@@ -1,3 +1,8 @@
+---
+creation_date: 2023-05-08
+state: approved
+---
+
 # Default PSS and Policy Exceptions with Kyverno
 
 ## Objective

--- a/logging-infrastructure/README.md
+++ b/logging-infrastructure/README.md
@@ -1,3 +1,8 @@
+---
+creation_date: 2023-01-12
+state: approved
+---
+
 # Logging infrastructure
 
 As a Giant Swarm engineer, I want to be able to access a history of logs for components managing our platform in order to both investigate ongoing operational issues and provide details for incident reports.

--- a/make-intranet-public/README.md
+++ b/make-intranet-public/README.md
@@ -1,3 +1,8 @@
+---
+creation_date: 2022-10-18
+state: approved
+---
+
 # Making parts of the intranet public
 
 ## Status quo

--- a/manage-essential-crds-via-mcb/README.md
+++ b/manage-essential-crds-via-mcb/README.md
@@ -1,3 +1,8 @@
+---
+creation_date: 2023-08-07
+state: approved
+---
+
 # Manage essential CRDs via MCB
 
 Essential CRDs are widely used ones by all / most of Giant Swarm apps in MCs, like VPA or Service Monitors.

--- a/managed-apps-vision/README.md
+++ b/managed-apps-vision/README.md
@@ -1,3 +1,8 @@
+---
+creation_date: 2021-11-24
+state: approved
+---
+
 # Managed Apps Vision
 
 This RFC describes a general vision for improving the user experience of Managed Apps.

--- a/management-cluster-access/README.md
+++ b/management-cluster-access/README.md
@@ -1,3 +1,8 @@
+---
+creation_date: 2023-01-25
+state: approved
+---
+
 # Ensure no single point of failure in management cluster access
 
 ## Access to management clusters for Giant Swarm staff
@@ -66,7 +71,7 @@ In the CAPI product, a kubeconfig is stored in LastPass as an emergency fallback
 
 - This method of authentication is completely separate from SSO and does not have shared dependencies.
 - It is not integrated in our tooling and we need to pull the kubeconfig using lastpass cli.
-- As it is right now, access is neither easily revokable nor is there a rotation. 
+- As it is right now, access is neither easily revokable nor is there a rotation.
 - In case of a security threat this implies rotating the api server CA and all certificates.
 - Since it is already integrated, it makes sense to keep it for emergencies while there is no alternative.
 - If we want to support this for a longer time we need to improve security.
@@ -101,7 +106,7 @@ Service account tokens are another one which we could revisit in the future. How
 
 This discussion is focused on management cluster access by GS staff and removing the single point of failure here should remain the goal.
 However, our chosen solution for other access related problems has impact on the issue of management cluster access by giant swarm staff. We should aim to resuse the same mechanisms for workload clusters and management clusters as much as possible. Likewise we should strive to dogfood mechanisms we offer to our customers.
-On the other hand, we should be conscious of differences between access for automation and controllers versus access for humans. 
+On the other hand, we should be conscious of differences between access for automation and controllers versus access for humans.
 Related problems include:
 
 - Access to management clusters for controllers
@@ -147,7 +152,7 @@ We already use lastpass as a fallback and we should keep it if possible. However
 We want to unify the way we authenticate to services. This also means deprecating auth0.
 - Identify which services still use auth0.
 - Migrate from auth0 to other identity providers. (Likely azure AD)
-  
+
 ### PKI story and future of client certificates
 
 This is largely reliant on the development of the CAPI product. Therefore we want to focus on SSO first and revisit client certificates at a later point in time.

--- a/merging-configmaps-gitops/README.md
+++ b/merging-configmaps-gitops/README.md
@@ -1,3 +1,8 @@
+---
+creation_date: 2022-04-01
+state: approved
+---
+
 # Merging config in a gitops context
 
 Our app platform utilizes configmaps / secrets heavily to pass configuration into apps.

--- a/monitoring-system-end-to-end-tests/README.md
+++ b/monitoring-system-end-to-end-tests/README.md
@@ -1,3 +1,8 @@
+---
+creation_date: 2021-07-26
+state: approved
+---
+
 # RFC 0003 - Monitoring System End To End Tests
 
 We're currently building a monitoring system that supports a large number of

--- a/multi-layer-app-config/README.md
+++ b/multi-layer-app-config/README.md
@@ -1,3 +1,8 @@
+---
+creation_date: 2022-06-20
+state: approved
+---
+
 # Multi layer app configs
 
 ## Intro

--- a/policy-orchestration/README.md
+++ b/policy-orchestration/README.md
@@ -1,9 +1,8 @@
 ---
-type: general
-stakeholders:
-    - sig-architecture
-    - team-shield
-issue: "tbd"
+creation_date: 2023-10-09
+owners:
+- https://github.com/orgs/giantswarm/teams/team-shield
+state: approved
 ---
 
 # Policy Orchestration System

--- a/pss-migration-orchestration/README.md
+++ b/pss-migration-orchestration/README.md
@@ -1,9 +1,8 @@
 ---
-type: general
-stakeholders:
-    - sig-architecture
-    - team-shield
-issue: "tbd"
+creation_date: 2023-10-09
+owners:
+- https://github.com/orgs/giantswarm/teams/team-shield
+state: approved
 ---
 
 # PSS migration orchestration

--- a/sig-meeting-improvement/README.md
+++ b/sig-meeting-improvement/README.md
@@ -1,3 +1,8 @@
+---
+creation_date: 2022-07-08
+state: approved
+---
+
 # SIG Meeting Improvement Initiative
 
 ## What are the problems we are experiencing?

--- a/simplify-basedomain-usage/README.md
+++ b/simplify-basedomain-usage/README.md
@@ -1,3 +1,8 @@
+---
+creation_date: 2023-05-31
+state: approved
+---
+
 # Simplify `baseDomain` usage in our applications
 
 The `baseDomain` is the common suffix that we use as a base for the DNS records created for our clusters.
@@ -87,7 +92,7 @@ On top of reducing the usage of the global `baseDomain` value, there are other a
 
 #### Custom Resources triggering changes rather than controllers
 
-Moving configuration from operators to custom resources is always preferable. Starting by the obvious, the cluster configuration is right there explicitly in the `Cluster` Custom resource rather than hidden in controllers configuration. 
+Moving configuration from operators to custom resources is always preferable. Starting by the obvious, the cluster configuration is right there explicitly in the `Cluster` Custom resource rather than hidden in controllers configuration.
 Furthermore, if the value is part of the `Cluster` CR, it's the `Cluster` the one driving and triggering changes on cloud resources, allowing clusters to change or update their values independently of each other.
 This is a better scenario than our current approach having the controller receive this configuration as a parameter, because changing the parameter would trigger changes in cloud resources on all clusters.
 
@@ -107,7 +112,7 @@ One side effect from this is that by decoupling the `baseDomain` from the Manage
 
 #### Make kubectl-gs more reliable when creating client certificates for WCs
 
-`kubectl-gs` could also use this annotation when creating client certificates for workload clusters. 
+`kubectl-gs` could also use this annotation when creating client certificates for workload clusters.
 Currently, it gets the cluster domain from the `Spec.ControlPlaneEndpoint.Host` property of the Cluster CR, which is not always accurate. Getting the domain from the annotation would fix it.
 
 ### Downsides

--- a/single-registry-architecture/README.md
+++ b/single-registry-architecture/README.md
@@ -1,16 +1,13 @@
+---
+creation_date: 2023-10-12
+issues: []
+owners:
+- https://github.com/orgs/giantswarm/teams/chapter-architecture
+state: approved
+summary: Switch to Azure Container Registry (ACR), even for China. Instead of replicating images across our multiple registries, trust this single provider to solve high availability. Run a local pull-through proxy to fall back during provider outage.
+---
+
 # Leaving docker hub and simplifying registries architecture
-
-## Date created
-
-03.10.2023
-
-## Last modified
-
-11.10.2023
-
-## Authors' emails
-
-<lukasz@giantswarm.io>
 
 ## Intro
 


### PR DESCRIPTION
As required by our new [decision process](https://github.com/giantswarm/rfc/tree/main/decision-process).

On top of the new check script, which also outputs the RFCs in a structured way, I'll add RFC rendering to the `handbook` repo.

I filled the `creation_date` field of each RFC from its oldest commit, and marked all RFCs as `state: approved`. We can clean up later and introduce missing fields for old RFCs. Only new RFCs require all fields while existing RFCs can remain with the minimal set `creation_date`/`state` for now.