### PR TITLE
Mark "Automatic App upgrades" RFC as obsolete

### DIFF
--- a/automatic-app-upgrades/README.md
+++ b/automatic-app-upgrades/README.md
@@ -1,6 +1,10 @@
 ---
 creation_date: 2022-04-15
-state: approved
+issues: []
+owners:
+- https://github.com/orgs/giantswarm/teams/team-honeybadger
+state: obsolete
+summary: Use Flux's watch features such as `ImagePolicy` to automatically upgrade to newer app versions. This change was not performed, but we use `*-collection` repos (on MCs) and cluster default apps (on MCs/WCs) instead, so this RFC is obsolete.
 ---
 
 # Automatic App upgrades


### PR DESCRIPTION
Towards [RFC cleanup issue](https://github.com/giantswarm/giantswarm/issues/29973).

See [chat](https://gigantic.slack.com/archives/C02GDJJ68Q1/p1721215080587169).