### PR TITLE
technical-decision-making-process: fix wording for publication

### DIFF
--- a/technical-decision-making-process/README.md
+++ b/technical-decision-making-process/README.md
@@ -12,16 +12,16 @@ summary: This contains the process for proposing, discussing, and formalizing te
 
 ### Problem statement
 
-The current technical decision-making process within our organization is inconsistent and inefficient, particularly when decisions impact multiple teams. This lack of a well-defined process leads to confusion, delays, and suboptimal decisions.
-We need a structured approach to proposing, discussing, and formalizing decisions to improve collaboration and decision quality.
+The technical decision-making process within our organization was found to be suboptimal, particularly when decisions impact multiple teams. The lack of well-defined steps towards a decision leads to confusion, delays, and suboptimal outcomes.
+We need a more structured approach to proposing, discussing, and formalizing decisions to improve collaboration and decision quality.
 
 The first [RFC and decision making process](https://handbook.giantswarm.io/docs/rfcs/decision-process/) proposed a file structure and introduced an overview of RFCs in the [Handbook](https://handbook.giantswarm.io/docs/rfcs/).
 It also suggested a process for submitting an RFC for a technical decision.
 
 This RFC extends the latter with a structure and introduces fields necessary for submitting a decision proposal.
-This enables a more structured approach to making decisions and specifies who the decision maker is, for whom it is mandatory to provide feedback, and in which timeframe. Additionally, it includes a communication plan to ensure clarity and alignment.
+Making our RFC framework more rigid will help reach decisions and specify who the decision maker is, for whom it is mandatory to provide feedback, and in which timeframe. Additionally, it includes a communication plan to ensure clarity and alignment.
 
-To help with an example, this RFC is itself in the proposed structure
+To provide an example, this RFC is itself in the proposed structure.
 
 ### Decision maker
 Team Horizon


### PR DESCRIPTION
### Summary

Improve wording in RFC `technical-decision-making-process` for publication.

Slack thread with background: https://gigantic.slack.com/archives/CV88V9A4U/p1721809362965709
