### PR TITLE
bump: flux resource version

### DIFF
--- a/multi-layer-app-config/README.md
+++ b/multi-layer-app-config/README.md
@@ -83,7 +83,7 @@ The merging algorithm is as follows:
 
 In case of multiple items in `extraConfigs` having the same priority, the order on the list is binding, with the item lower on the list being merged later (overriding those higher on the list).
 
-The idea is modeled after Flux's [HelmRelease configuration](https://fluxcd.io/docs/components/helm/api/#helm.toolkit.fluxcd.io/v2beta1.ValuesReference).
+The idea is modeled after Flux's [HelmRelease configuration](https://fluxcd.io/docs/components/helm/api/#helm.toolkit.fluxcd.io/v2.ValuesReference).
 
 #### Example
 


### PR DESCRIPTION
Torwards flux 2.

@ljakimczuk you changed this in giantswar/handbook https://github.com/giantswarm/handbook/pull/461 but it would be overriden again by this repository, via https://github.com/giantswarm/handbook/pull/462 .

So please approve this PR to make your change to the RFC persistent.