### PR TITLE
fix(check-rfc-format.py): front-matter style warnings

### DIFF
--- a/semver-based-automatic-upgrades/README.md
+++ b/semver-based-automatic-upgrades/README.md
@@ -1,15 +1,13 @@
 ---
 creation_date: 2025-12-11
 issues:
-  - https://github.com/giantswarm/giantswarm/issues/24237
+- https://github.com/giantswarm/giantswarm/issues/24237
 last_review_date: 2026-06-08
 owners:
-  - https://github.com/orgs/giantswarm/teams/team-honeybadger
+- https://github.com/orgs/giantswarm/teams/team-honeybadger
 state: approved
-summary:
-  We want to use flux and flux-operator's automatic upgrades capabilities to create automatic upgrades for
-  different release stages, so we don't have to manually or through extra automation care about those
-  rollouts.
+summary: We want to use flux and flux-operator's automatic upgrades capabilities to create automatic upgrades for
+different release stages, so we don't have to manually or through extra automation care about those rollouts.
 ---
 
 # Using semVer tags for automatic app upgrades in different release stages

--- a/semver-based-automatic-upgrades/README.md
+++ b/semver-based-automatic-upgrades/README.md
@@ -6,8 +6,7 @@ last_review_date: 2026-06-08
 owners:
 - https://github.com/orgs/giantswarm/teams/team-honeybadger
 state: approved
-summary: We want to use flux and flux-operator's automatic upgrades capabilities to create automatic upgrades for
-different release stages, so we don't have to manually or through extra automation care about those rollouts.
+summary: We want to use flux and flux-operator's automatic upgrades capabilities to create automatic upgrades for different release stages, so we don't have to manually or through extra automation care about those rollouts.
 ---
 
 # Using semVer tags for automatic app upgrades in different release stages


### PR DESCRIPTION
Small front-matter indentation fixes, to avoid  `check-rfc-format.py` throwing errors.