### PR TITLE
feat(decision-process): record decisions surfaced during RFC review

### DIFF
--- a/.github/rfc-format/check-rfc-format.py
+++ b/.github/rfc-format/check-rfc-format.py
@@ -55,6 +55,96 @@ ISSUE_URL_REGEX = re.compile(
 )
 OLD_RFC_NUMBER_IN_TITLE_REGEX = re.compile(r'RFC \d+\s*(-\s*)?')
 TRAILING_WHITESPACE_REGEX = re.compile(r'[ \t\v]+$', flags=re.MULTILINE)
+# Heading of a single decision entry inside the optional "## Decisions" section, e.g.
+# "### 2026-07-16 Stages are provider-specific". Date is required, title is captured separately.
+DECISION_HEADING_REGEX = re.compile(r'^### (\d{4}-\d{2}-\d{2})(?:\s+(.+?))?\s*$')
+
+
+def parse_decisions(content):
+    """Parse the optional "## Decisions" section, returning (decisions, problems).
+
+    Decisions are optional. If a "## Decisions" section is present, its entries must follow the
+    documented format (see decision-process/README.md): one "### YYYY-MM-DD Title" heading per
+    decision, each with a non-empty description. Fenced code blocks are ignored so that
+    documentation examples aren't parsed as real decisions.
+    """
+    problems = []
+    decisions = []
+    lines = content.splitlines()
+
+    def strip_fenced(numbered_lines):
+        in_fence = False
+        for item in numbered_lines:
+            if item[1].lstrip().startswith('```'):
+                in_fence = not in_fence
+                continue
+            if not in_fence:
+                yield item
+
+    section_starts = [i for i, line in strip_fenced(list(enumerate(lines))) if line.strip() == '## Decisions']
+    if not section_starts:
+        return decisions, problems
+    if len(section_starts) > 1:
+        problems.append('There must be at most one "## Decisions" section.')
+
+    # Collect the section body: everything after the heading until the next H2 (ignoring fences).
+    block = []
+    in_fence = False
+    for line in lines[section_starts[0] + 1:]:
+        if line.lstrip().startswith('```'):
+            in_fence = not in_fence
+        elif not in_fence and line.startswith('## '):
+            break
+        block.append(line)
+
+    # Split the block into decision entries by their "### " headings (ignoring fenced content).
+    # Anything before the first heading is preamble and must not carry decision content.
+    entries = []
+    preamble = []
+    in_fence = False
+    for line in block:
+        if line.lstrip().startswith('```'):
+            in_fence = not in_fence
+        elif not in_fence and line.startswith('### '):
+            entries.append([line, []])
+            continue
+        (entries[-1][1] if entries else preamble).append(line)
+
+    if any(line.strip() for line in preamble):
+        problems.append(
+            'Content under "## Decisions" must live inside a "### YYYY-MM-DD Title" entry, not before the first one.')
+    if not entries:
+        problems.append(
+            'A "## Decisions" section must contain at least one "### YYYY-MM-DD Title" entry, or be omitted entirely.')
+
+    for heading, body in entries:
+        match = DECISION_HEADING_REGEX.match(heading)
+        if not match:
+            problems.append(
+                'Each decision under "## Decisions" must use the heading format "### YYYY-MM-DD Title". '
+                f'Got: {heading!r}')
+            continue
+
+        date_str, title = match.group(1), (match.group(2) or '').strip()
+        try:
+            decision_date = datetime.date.fromisoformat(date_str)
+        except ValueError:
+            problems.append(f'Decision heading has an invalid date (want YYYY-MM-DD): {heading!r}')
+            continue
+        if not (2021 <= decision_date.year <= 2100):
+            problems.append(f'Decision heading date has an unexpected year: {heading!r}')
+        if not title:
+            problems.append(
+                f'Decision heading is missing a title after the date. The title should state the decision. '
+                f'Got: {heading!r}')
+
+        body_text = '\n'.join(body).strip()
+        if not body_text:
+            problems.append(f'Decision "{heading.strip()}" has no description below it.')
+
+        decisions.append({'date': date_str, 'title': title, 'content': body_text})
+
+    return decisions, problems
 
 
 def check_rfc(rfc_dir):
@@ -211,6 +301,10 @@ def check_rfc(rfc_dir):
         problems.append(
             'Could not find title. Please add a H1 heading (e.g. `# This is my RFC title`) after the YAML header.')
 
+    decisions, decision_problems = parse_decisions(rfc.content)
+    problems.extend(decision_problems)
+    rfc.metadata['decisions'] = decisions
+
     if problems:
         raise RfcFormatProblems(problems)
 
@@ -252,6 +346,7 @@ def main():
             # in the handbook.
             rfcs_json.append({
                 'creation_date': rfc.metadata['creation_date'].isoformat(),
+                'decisions': rfc.metadata['decisions'],
                 'markdown_content_without_title': rfc.metadata['markdown_content_without_title'],
                 'slug': entry_name,
                 'state': rfc.metadata['state'],

--- a/decision-process/README.md
+++ b/decision-process/README.md
@@ -2,6 +2,7 @@
 creation_date: 2023-10-10
 issues:
 - https://github.com/giantswarm/giantswarm/issues/24661
+last_review_date: 2026-07-16
 owners:
 - https://github.com/orgs/giantswarm/teams/sig-architecture
 - https://github.com/orgs/giantswarm/teams/team-planeteers
@@ -109,6 +110,24 @@ Therefore, we will automatically render the merged RFCs into our [handbook](http
 - **Author merges the PR and notifies in `#news-*` or other Slack channels, linking to the [RFC list](https://handbook.giantswarm.io/docs/rfcs/) or directly to the rendered RFC page in the handbook.** The rendering result is not ready immediately after merging, but [a pull request on the handbook repo](https://github.com/giantswarm/handbook/pulls) with the rendered results should be opened automatically. You can merge it and the handbook will be updated after deployment (takes another few minutes). If things don't work, you can check the [`rfc` rendering trigger action](https://github.com/giantswarm/rfc/actions) and [`handbook` rendering action](https://github.com/giantswarm/handbook/actions) and notify SIG Docs about any problems.
 - **Once the decision is approved, plan for implementation.** Implementation really should not happen before approving a decision, unless it's a proof of feasability. If you already developed something, you present an RFC as if others still have the choice of saying no, but actually the decision was already taken – please avoid that.
 - **Amendments can be made to an RFC later, by means of a simple PR, consensus, and notification in Slack.** Please edit the existing RFC file and consider marking the changes as "amendment", for example using a new heading or paragraph. There should be a single file per decision, not multiple documents that need to be read and understood together. Replaced or old RFC files can remain as they are, in separate files, but marked as `state: obsolete` through a PR.
+
+### Recording decisions during review
+
+During review, decisions related to the content of the PR may come to light which are pertinent to the approval of the RFC. Record them at the bottom of the RFC **prior to approval** in a section that uses these headings **verbatim**, so decisions stay uniform across all RFCs and can be found and rendered automatically:
+
+```markdown
+## Decisions
+
+### YYYY-MM-DD The decision, stated in the heading
+
+Context and reasoning behind the decision.
+```
+
+- Use the literal heading `## Decisions` and date-prefixed `### YYYY-MM-DD ...` entries. Do not rename them (e.g. "Decision log", "Resolved questions") — consistency is what makes them discoverable.
+- The `###` title should **state the decision**, not just name the topic. Prefer `### 2026-07-16 Stages are provider-specific` over `### 2026-07-16 Stages`, so the heading alone summarises.
+- The `## Decisions` section is the **canonical** record. The RFC body may explain a decision in more depth, but the ruling itself lives here; if the two ever disagree, this section wins.
+
+This ensures that critical decisions related to the RFC and its later implementation are not left buried inside comments or Slack threads.
 
 ### State transitions
 

--- a/decision-process/README.md
+++ b/decision-process/README.md
@@ -120,7 +120,7 @@ During review, decisions related to the content of the PR may come to light whic
 
 ### YYYY-MM-DD The decision, stated in the heading
 
-Context and reasoning behind the decision.
+Description and reasoning behind the decision.
 ```
 
 - Use the literal heading `## Decisions` and date-prefixed `### YYYY-MM-DD ...` entries. Do not rename them (e.g. "Decision log", "Resolved questions") — consistency is what makes them discoverable.


### PR DESCRIPTION
As part of an RFC review, some decisions may come to light that relate to the expected outcome of the RFC. At present these can get lost inside PR comments or Slack threads without a formal record being made.

To improve discoverability, RFCs may now carry an optional `## Decisions` section with dated `### YYYY-MM-DD Title` entries recorded before approval. The format checker validates the section when present and exports the decisions into the rendered JSON so they surface in the handbook.

Existing RFCs are unaffected; the section is optional and not back-ported.